### PR TITLE
[WIP] Initial work to support multiple instances

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,7 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutversion"
+    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
 
     implementation("com.jakewharton.threetenabp:threetenabp:$threeTenAbpVersion") {
         exclude group: 'org.threeten'

--- a/app/src/main/java/io/homeassistant/companion/android/PresenterComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/PresenterComponent.kt
@@ -6,6 +6,8 @@ import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
 import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationFragment
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupFragment
+import io.homeassistant.companion.android.settings.SettingsActivity
+import io.homeassistant.companion.android.settings.manageinstances.ManageInstancesFragment
 import io.homeassistant.companion.android.webview.WebViewActivity
 
 @Component(dependencies = [AppComponent::class], modules = [PresenterModule::class])
@@ -20,5 +22,9 @@ interface PresenterComponent {
     fun inject(fragment: MobileAppIntegrationFragment)
 
     fun inject(activity: WebViewActivity)
+
+    fun inject(activity: SettingsActivity)
+
+    fun inject(fragment: ManageInstancesFragment)
 
 }

--- a/app/src/main/java/io/homeassistant/companion/android/PresenterModule.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/PresenterModule.kt
@@ -15,6 +15,12 @@ import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegr
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupPresenter
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupPresenterImpl
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupView
+import io.homeassistant.companion.android.settings.SettingsPresenter
+import io.homeassistant.companion.android.settings.SettingsPresenterImpl
+import io.homeassistant.companion.android.settings.SettingsView
+import io.homeassistant.companion.android.settings.manageinstances.ManageInstancePresenterImpl
+import io.homeassistant.companion.android.settings.manageinstances.ManageInstancePresenter
+import io.homeassistant.companion.android.settings.manageinstances.ManageInstanceView
 import io.homeassistant.companion.android.webview.WebView
 import io.homeassistant.companion.android.webview.WebViewPresenter
 import io.homeassistant.companion.android.webview.WebViewPresenterImpl
@@ -27,6 +33,8 @@ class PresenterModule {
     private lateinit var manualSetupView: ManualSetupView
     private lateinit var mobileAppIntegrationView: MobileAppIntegrationView
     private lateinit var webView: WebView
+    private lateinit var settingsView: SettingsView
+    private lateinit var manageInstanceView: ManageInstanceView
 
     constructor(launchView: LaunchView) {
         this.launchView = launchView
@@ -48,6 +56,14 @@ class PresenterModule {
         this.webView = webView
     }
 
+    constructor(settingsView: SettingsView) {
+        this.settingsView = settingsView
+    }
+
+    constructor(manageInstanceView: ManageInstanceView) {
+        this.manageInstanceView = manageInstanceView
+    }
+
     @Provides
     fun provideLaunchView() = launchView
 
@@ -62,6 +78,12 @@ class PresenterModule {
 
     @Provides
     fun provideWebView() = webView
+
+    @Provides
+    fun providesSettingsView() = settingsView
+
+    @Provides
+    fun providesManageInstanceView() = manageInstanceView
 
     @Module
     interface Declaration {
@@ -80,6 +102,12 @@ class PresenterModule {
 
         @Binds
         fun bindWebViewPresenterImpl(presenter: WebViewPresenterImpl): WebViewPresenter
+
+        @Binds
+        fun bindSettingsPresenterImpl(presenter: SettingsPresenterImpl): SettingsPresenter
+
+        @Binds
+        fun bindManageInstancePresenterImpl(presenter: ManageInstancePresenterImpl): ManageInstancePresenter
 
 
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -3,13 +3,23 @@ package io.homeassistant.companion.android.settings
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.Group
+import androidx.fragment.app.Fragment
 import io.homeassistant.companion.android.BuildConfig
+import io.homeassistant.companion.android.DaggerPresenterComponent
+import io.homeassistant.companion.android.PresenterModule
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.onboarding.OnboardingActivity
+import io.homeassistant.companion.android.settings.manageinstances.ManageInstancesFragment
+import javax.inject.Inject
 
 
-class SettingsActivity : AppCompatActivity() {
+class SettingsActivity : AppCompatActivity(), SettingsView {
 
     companion object {
         fun newInstance(context: Context): Intent {
@@ -17,11 +27,67 @@ class SettingsActivity : AppCompatActivity() {
         }
     }
 
+    @Inject
+    lateinit var presenter: SettingsPresenter
+    var manageInstancesFragment: ManageInstancesFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
-        findViewById<TextView>(R.id.version_text_view).text = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
+
+        DaggerPresenterComponent
+            .builder()
+            .appComponent((application as GraphComponentAccessor).appComponent)
+            .presenterModule(PresenterModule(this))
+            .build()
+            .inject(this)
+
+        findViewById<TextView>(R.id.app_version_text_view).text =
+            getString(R.string.app_version_text).format(
+                BuildConfig.VERSION_NAME,
+                BuildConfig.VERSION_CODE
+            )
+        findViewById<Button>(R.id.logout_button).setOnClickListener { presenter.logout() }
+        findViewById<Button>(R.id.manage_instances_button).setOnClickListener { presenter.addNewInstance() }
     }
 
+    override fun redirectToOnboarding() {
+        finish()
+        startActivity(Intent(this, OnboardingActivity::class.java))
+    }
+
+    override fun onBackPressed() {
+        if (supportFragmentManager.backStackEntryCount > 0) {
+            supportFragmentManager.popBackStackImmediate()
+            findViewById<Group>(R.id.settings_group).visibility = View.VISIBLE
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    override fun manageInstances() {
+        val fragment =
+            supportFragmentManager.findFragmentByTag(ManageInstancesFragment.TAG)
+        if (fragment == null) {
+            manageInstancesFragment = ManageInstancesFragment.newInstance()
+            replaceFragmentInActivity(
+                manageInstancesFragment as ManageInstancesFragment,
+                R.id.manage_instances_fragment_container
+            )
+        } else {
+            replaceFragmentInActivity(
+                fragment as ManageInstancesFragment,
+                R.id.manage_instances_fragment_container
+            )
+        }
+        findViewById<Group>(R.id.settings_group).visibility = View.GONE
+    }
+
+    private fun replaceFragmentInActivity(fragment: Fragment, frameId: Int) {
+        val ft = supportFragmentManager.beginTransaction()
+        ft.replace(frameId, fragment, fragment.tag)
+        ft.addToBackStack(fragment.tag)
+        ft.commit()
+
+    }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -1,0 +1,8 @@
+package io.homeassistant.companion.android.settings
+
+interface SettingsPresenter {
+
+    fun logout()
+
+    fun addNewInstance()
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.settings
+
+import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class SettingsPresenterImpl @Inject constructor(
+    private val view: SettingsView,
+    private val authenticationUseCase: AuthenticationUseCase
+) : SettingsPresenter {
+
+    private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
+
+    override fun logout() {
+        mainScope.launch {
+            authenticationUseCase.revokeSession()
+        }
+        view.redirectToOnboarding()
+    }
+
+    override fun addNewInstance() {
+        view.manageInstances()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsView.kt
@@ -1,0 +1,8 @@
+package io.homeassistant.companion.android.settings
+
+interface SettingsView {
+
+    fun redirectToOnboarding()
+
+    fun manageInstances()
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstacesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstacesFragment.kt
@@ -1,0 +1,83 @@
+package io.homeassistant.companion.android.settings.manageinstances
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.homeassistant.companion.android.DaggerPresenterComponent
+import io.homeassistant.companion.android.PresenterModule
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.onboarding.OnboardingActivity
+import io.homeassistant.companion.android.webview.WebViewActivity
+import javax.inject.Inject
+
+class ManageInstancesFragment : Fragment(), ManageInstanceView,
+    ManageInstanceAdapter.InstanceInterface {
+
+    companion object {
+        const val TAG = "ManageInstancesFragment"
+        fun newInstance() =
+            ManageInstancesFragment()
+    }
+
+    @Inject
+    lateinit var presenter: ManageInstancePresenter
+    private var adapter: ManageInstanceAdapter? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        DaggerPresenterComponent
+            .builder()
+            .appComponent((activity?.application as GraphComponentAccessor).appComponent)
+            .presenterModule(PresenterModule(this))
+            .build()
+            .inject(this)
+        adapter = ManageInstanceAdapter(this)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_manage_instances, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val recyclerView = view.findViewById(R.id.instance_recycler_view) as RecyclerView
+        recyclerView.layoutManager = LinearLayoutManager(this.context)
+        recyclerView.adapter = adapter
+        presenter.getInstances()
+        view.findViewById<Button>(R.id.add_new_instance_button)
+            .setOnClickListener { presenter.addNewInstance() }
+    }
+
+    override fun showInstanceList(instances: List<String>) {
+        adapter?.instances = instances
+        adapter?.notifyDataSetChanged()
+    }
+
+    override fun launchInstance() {
+        startActivity(WebViewActivity.newInstance(activity!!))
+        activity?.finish()
+    }
+
+    override fun onInstanceSelected(urlString: String) {
+        presenter.switchToInstance(urlString)
+    }
+
+    override fun onDeleteInstance(urlString: String) {
+        presenter.deleteInstance(urlString)
+    }
+
+    override fun addNewInstance() {
+        startActivity(Intent(activity, OnboardingActivity::class.java))
+        activity?.finish()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstanceAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstanceAdapter.kt
@@ -1,0 +1,60 @@
+package io.homeassistant.companion.android.settings.manageinstances
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import io.homeassistant.companion.android.R
+
+class ManageInstanceAdapter(private val instanceInterface: ManageInstanceAdapter.InstanceInterface) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    var instances: List<String> =
+        ArrayList()
+
+    init {
+        setHasStableIds(true)
+    }
+
+    interface InstanceInterface {
+        fun onInstanceSelected(urlString: String)
+        fun onDeleteInstance(urlString: String)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return InstanceViewHolder(
+            LayoutInflater.from(parent.context)
+                .inflate(R.layout.instance_view, parent, false)
+        )
+    }
+
+    override fun getItemCount() = instances.count()
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        holder as InstanceViewHolder
+        holder.bind(instances[position])
+        holder.itemView.setOnClickListener {
+            instanceInterface.onInstanceSelected(
+                holder.itemView.findViewById<TextView>(
+                    R.id.instance_name
+                ).text.toString()
+            )
+        }
+        holder.itemView.findViewById<Button>(R.id.delete_button).setOnClickListener {
+            instanceInterface.onDeleteInstance(
+                holder.itemView.findViewById<TextView>(
+                    R.id.instance_name
+                ).text.toString()
+            )
+        }
+    }
+
+    class InstanceViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+        fun bind(header: String) {
+            itemView.findViewById<TextView>(R.id.instance_name).text = header
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstancePresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstancePresenter.kt
@@ -1,0 +1,12 @@
+package io.homeassistant.companion.android.settings.manageinstances
+
+interface ManageInstancePresenter {
+
+    fun getInstances()
+
+    fun switchToInstance(url: String)
+
+    fun addNewInstance()
+
+    fun deleteInstance(url: String)
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstancePresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstancePresenterImpl.kt
@@ -1,0 +1,39 @@
+package io.homeassistant.companion.android.settings.manageinstances
+
+import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
+import kotlinx.coroutines.*
+import javax.inject.Inject
+
+class ManageInstancePresenterImpl @Inject constructor(
+    private val view: ManageInstanceView,
+    private val authenticationUseCase: AuthenticationUseCase
+) : ManageInstancePresenter {
+
+    private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
+    private var instanceList: List<String>? = null
+
+    override fun getInstances() {
+        mainScope.launch {
+            instanceList = withContext(Dispatchers.IO) {
+                authenticationUseCase.getAllInstanceUrls()
+            }
+            instanceList?.let {
+                view.showInstanceList(it)
+            }
+        }
+    }
+
+    override fun switchToInstance(url: String) {
+        mainScope.launch { authenticationUseCase.setCurrentInstance(url) }
+        view.launchInstance()
+    }
+
+    override fun addNewInstance() {
+        view.addNewInstance()
+    }
+
+    override fun deleteInstance(url: String) {
+        mainScope.launch { authenticationUseCase.deleteInstance(url) }
+        getInstances()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstanceView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/manageinstances/ManageInstanceView.kt
@@ -1,0 +1,7 @@
+package io.homeassistant.companion.android.settings.manageinstances
+
+interface ManageInstanceView {
+    fun showInstanceList(instances: List<String>)
+    fun launchInstance()
+    fun addNewInstance()
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -29,7 +29,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         }
     }
 
-    @Inject lateinit var presenter: WebViewPresenter
+    @Inject
+    lateinit var presenter: WebViewPresenter
     private lateinit var webView: WebView
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -85,7 +86,9 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                     Log.d(TAG, "Callback $it")
                                 }
                             }
-                            JSONObject(message).get("type") == "config_screen/show" -> startActivity(SettingsActivity.newInstance(this@WebViewActivity))
+                            JSONObject(message).get("type") == "config_screen/show" -> startActivity(
+                                SettingsActivity.newInstance(this@WebViewActivity)
+                            )
                         }
                     }
                 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -5,6 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/settings_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:constraint_referenced_ids="title,icon,app_version_text_view,manage_instances_button,logout_button" />
+
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/title"
         style="@style/TextAppearance.HomeAssistant.Headline"
@@ -27,13 +33,36 @@
         app:srcCompat="@drawable/app_icon" />
 
     <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/version_text_view"
+        android:id="@+id/app_version_text_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/icon"
-        tools:text="1.0.0 (1)" />
+        tools:text="App: 1.0.0 (1)" />
+
+    <FrameLayout
+        android:id="@+id/manage_instances_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/manage_instances_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Manage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_version_text_view" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/logout_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/logout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/manage_instances_button" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_manage_instances.xml
+++ b/app/src/main/res/layout/fragment_manage_instances.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:orientation="vertical"
+    tools:context=".settings.manageinstances.ManageInstancesFragment">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/instance_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/add_new_instance_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:text="Add new"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/instance_view.xml
+++ b/app/src/main/res/layout/instance_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/instance_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        tools:text="https://home-assistant.io/demo"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/delete_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="delete"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,10 @@
     <string name="checking_with_home_assistant">Checking with Home Assistant</string>
     <string name="skip">Skip</string>
     <string name="retry">Retry</string>
+    <string name="logout">Logout</string>
     <string name="attempting_registration">Attempting to register application…</string>
     <string name="unable_to_register">Unable to Register Application</string>
     <string name="error_with_registration">Please check to ensure you have the mobile_app \nintegration enabled on your home assistant instance.</string>
+    <string name="app_version_text">App: %s (%s)</string>
+    <string name="server_version_text">Server: %s</string>
 </resources>

--- a/data/src/main/java/io/homeassistant/companion/android/data/authentication/Session.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/authentication/Session.kt
@@ -1,12 +1,17 @@
 package io.homeassistant.companion.android.data.authentication
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.threeten.bp.Instant
 
 
 data class Session(
+    @JsonProperty("accessToken")
     val accessToken: String,
+    @JsonProperty("expiresTimestamp")
     val expiresTimestamp: Long,
+    @JsonProperty("refreshToken")
     val refreshToken: String,
+    @JsonProperty("tokenType")
     val tokenType: String
 ) {
 

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationRepository.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationRepository.kt
@@ -21,4 +21,10 @@ interface AuthenticationRepository {
 
     suspend fun buildBearerToken(): String
 
+    suspend fun getAllInstanceUrls(): List<String>
+
+    suspend fun setCurrentInstance(url: String)
+
+    suspend fun deleteInstance(url: String)
+
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationUseCase.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationUseCase.kt
@@ -19,4 +19,10 @@ interface AuthenticationUseCase {
 
     suspend fun buildAuthenticationUrl(callbackUrl: String): URL
 
+    suspend fun getAllInstanceUrls(): List<String>
+
+    suspend fun setCurrentInstance(url: String)
+
+    suspend fun deleteInstance(url: String)
+
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationUseCaseImpl.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/authentication/AuthenticationUseCaseImpl.kt
@@ -35,4 +35,15 @@ class AuthenticationUseCaseImpl @Inject constructor(
         return authenticationRepository.buildAuthenticationUrl(callbackUrl)
     }
 
+    override suspend fun getAllInstanceUrls(): List<String> {
+        return authenticationRepository.getAllInstanceUrls()
+    }
+
+    override suspend fun setCurrentInstance(url: String) {
+        return authenticationRepository.setCurrentInstance(url)
+    }
+
+    override suspend fun deleteInstance(url: String) {
+        return authenticationRepository.deleteInstance(url)
+    }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,6 +7,7 @@ ext {
     jacksonVersion = '2.9.10'
     appCompatVersion = '1.1.0'
     constraintLayoutversion = '1.1.3'
+    recyclerViewVersion = '1.1.0'
     coroutinesVersion = '1.3.2'
     daggerVersion = '2.25.2'
     threeTenAbpVersion = '1.2.1'


### PR DESCRIPTION
This is far from complete, but wanted to get some opinions on it. 

Basically is this something we would be okay with having or am I wasting my time? The goal is to allow users to switch between multiple HA servers using one app, without having to login/out every time. 

This has the ability to list multiple instances in the settings page, with the ability to select and switch to the other instance. You can also delete instances.

Things that I think need done before I would consider this complete.

- [ ] Only allow deleting instances that aren't the current
- [ ] Don't allow selecting the current instance
- [ ] If you are logged out and there are other instances fallback to another one don't go to onboarding
- [ ] Instances get "saved" even if they don't get logged in
- [ ] The settings activity UI should probably be moved to a fragment
