### PR TITLE
Add Lokalise SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,9 @@ dependencies {
 
     implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
 
+    implementation 'com.lokalise.android:ota-sdk:1.3.15'
+    implementation 'com.google.code.gson:gson:2.8.0'
+
     implementation 'com.google.android.gms:play-services-location:17.0.0'
 
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek2Version"

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -5,6 +5,7 @@ import com.jakewharton.threetenabp.AndroidThreeTen
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import co.lokalise.android.sdk.LokaliseSDK
 
 class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
@@ -12,6 +13,9 @@ class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
     override fun onCreate() {
         super.onCreate()
+
+        LokaliseSDK.init("16ff9dee3da7a3cba0d998a4e58fa99e92ba089d", "145814835dd655bc5ab0d0.36753359", this)
+        LokaliseSDK.updateTranslations()
 
         AndroidThreeTen.init(this)
         graph = Graph(this)

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -1,11 +1,11 @@
 package io.homeassistant.companion.android
 
 import android.app.Application
+import co.lokalise.android.sdk.LokaliseSDK
 import com.jakewharton.threetenabp.AndroidThreeTen
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
-import co.lokalise.android.sdk.LokaliseSDK
 
 class HomeAssistantApplication : Application(), GraphComponentAccessor {
 

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -1,9 +1,10 @@
 package io.homeassistant.companion.android.launch
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
+import co.lokalise.android.sdk.core.LokaliseContextWrapper
 import io.homeassistant.companion.android.DaggerPresenterComponent
 import io.homeassistant.companion.android.PresenterModule
 import io.homeassistant.companion.android.background.LocationBroadcastReceiver
@@ -11,7 +12,6 @@ import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
-import co.lokalise.android.sdk.core.LokaliseContextWrapper
 
 class LaunchActivity : AppCompatActivity(), LaunchView {
 

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.launch
 
 import android.content.Intent
 import android.os.Bundle
+import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import io.homeassistant.companion.android.DaggerPresenterComponent
 import io.homeassistant.companion.android.PresenterModule
@@ -10,11 +11,11 @@ import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
+import co.lokalise.android.sdk.core.LokaliseContextWrapper
 
 class LaunchActivity : AppCompatActivity(), LaunchView {
 
-    @Inject
-    lateinit var presenter: LaunchPresenter
+    @Inject lateinit var presenter: LaunchPresenter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -47,5 +48,9 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
     override fun onDestroy() {
         presenter.onFinish()
         super.onDestroy()
+    }
+
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LokaliseContextWrapper.wrap(newBase))
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import co.lokalise.android.sdk.core.LokaliseContextWrapper
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationListener
@@ -14,7 +15,6 @@ import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegr
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupFragment
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupListener
 import io.homeassistant.companion.android.webview.WebViewActivity
-import co.lokalise.android.sdk.core.LokaliseContextWrapper
 
 class OnboardingActivity : AppCompatActivity(), DiscoveryListener, ManualSetupListener,
     AuthenticationListener, MobileAppIntegrationListener {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegr
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupFragment
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupListener
 import io.homeassistant.companion.android.webview.WebViewActivity
+import co.lokalise.android.sdk.core.LokaliseContextWrapper
 
 class OnboardingActivity : AppCompatActivity(), DiscoveryListener, ManualSetupListener,
     AuthenticationListener, MobileAppIntegrationListener {
@@ -82,5 +83,9 @@ class OnboardingActivity : AppCompatActivity(), DiscoveryListener, ManualSetupLi
     private fun startWebView() {
         startActivity(WebViewActivity.newInstance(this))
         finish()
+    }
+
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LokaliseContextWrapper.wrap(newBase))
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -11,6 +11,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import co.lokalise.android.sdk.core.LokaliseContextWrapper
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.DaggerPresenterComponent
 import io.homeassistant.companion.android.PresenterModule
@@ -146,5 +147,9 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     override fun onDestroy() {
         presenter.onFinish()
         super.onDestroy()
+    }
+
+    override fun attachBaseContext(newBase: Context?) {
+        super.attachBaseContext(LokaliseContextWrapper.wrap(newBase))
     }
 }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <string name="app_name">Home Assistant</string>
+  <string name="scanning_network">Ricerca Home Assistant in corso.
+Scansione della rete</string>
+  <string name="home_assistant_not_discover">Impossibile trovate 
+il tuo Home Assistant</string>
+  <string name="connect_to_home_internet">Assicurati che il telefono sia collegato 
+a Internet di casa tua.</string>
+  <string name="scan_again">Cerca di nuovo</string>
+  <string name="manual_setup">inserisci l\'indirizzo manualmente</string>
+  <string name="input_url">URL Home Assistant</string>
+  <string name="input_url_hint">https://esempio.duckdns.org:8123</string>
+  <string name="status_of_mobile_app_integration">Stato integrazione della mobile app:</string>
+  <string name="checking_with_home_assistant">Verifica Home Assistant in corso</string>
+  <string name="skip">Salta</string>
+  <string name="retry">Riprova</string>
+  <string name="attempting_registration">Tentativo di registrazione dell\'applicazione...</string>
+  <string name="unable_to_register">Impossibile registrare l\'applicazione</string>
+  <string name="error_with_registration">Varifica di avere l\'integrazione mobile_app abilitata 
+sul tuo home assistant.</string>
+  <string name="url_parse_error">Impossibile analizzare l\'URL di Home Assistant. Dovrebbe somigliare a https://esempio.com</string>
+</resources>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <string name="app_name">Home Assistant</string>
+  <string name="scanning_network">Netwerk scannen naar Home Assistant</string>
+  <string name="home_assistant_not_discover">Home Assistant instantie niet gevonden</string>
+  <string name="connect_to_home_internet">Je telefoon dient verbonden te zijn met je thuis netwerk.</string>
+  <string name="scan_again">opnieuw scannen</string>
+  <string name="manual_setup">Adres handmatig invullen</string>
+  <string name="input_url">Home Assistant adres</string>
+  <string name="input_url_hint">https://example.duckdns.org:8123</string>
+  <string name="status_of_mobile_app_integration">Status van mobiele app integratie:</string>
+  <string name="checking_with_home_assistant">Controleren met Home Assistant</string>
+  <string name="skip">Overslaan</string>
+  <string name="retry">Opnieuw proberen</string>
+  <string name="attempting_registration">Proberen om de applicatie te registreren...</string>
+  <string name="unable_to_register">Niet mogelijk om de applicatie te registeren.</string>
+  <string name="error_with_registration">Controleer of de mobile_app integratie is ingeschakeld in je Home Assistant instantie.</string>
+  <string name="url_parse_error">Je Home Assistant URL lijkt niet te kloppen. Het zou ongeveer hetzelfde moeten zijn als https://example.com</string>
+</resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <string name="app_name">Home Assistant</string>
+  <string name="scanning_network">Skanowanie sieci w poszukiwaniu Home Assistant\'a</string>
+  <string name="home_assistant_not_discover">Nie można znaleźć Twojego Home Assistant\'a</string>
+  <string name="connect_to_home_internet">Upewnij się, że telefon jest podłączony do sieci domowej.</string>
+  <string name="scan_again">skanuj ponownie</string>
+  <string name="manual_setup">wprowadź adres ręcznie</string>
+  <string name="input_url">Adres URL Home Assistant\'a</string>
+  <string name="input_url_hint">https://example.duckdns.org:8123</string>
+  <string name="status_of_mobile_app_integration">Status integracji mobile_app:</string>
+  <string name="checking_with_home_assistant">Sprawdzanie z Home Assistant\'em</string>
+  <string name="skip">Pomiń</string>
+  <string name="retry">Ponów próbę</string>
+  <string name="attempting_registration">Próba zarejestrowania aplikacji…</string>
+  <string name="unable_to_register">Nie można zarejestrować aplikacji</string>
+  <string name="error_with_registration">Sprawdź, czy integracja mobile_app jest włączona w Twoim instancji Home Assistant\'a.</string>
+  <string name="url_parse_error">Nie można rozpoznać adresu URL Home Assistant\'a. Powinien on wyglądać następująco https://example.com</string>
+</resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+  <string name="app_name">Home Assistant</string>
+  <string name="scanning_network">Se caută o instanță a Home Assistant-ul in rețeaua locală </string>
+  <string name="home_assistant_not_discover">Nu am găsit instanța Home Assistant-ului</string>
+  <string name="connect_to_home_internet">Asigurați-vă că telefonul dvs. este conectat 
+ la rețeaua locală.</string>
+  <string name="scan_again">scaneaza inca o data</string>
+  <string name="manual_setup">ntroduceți manual adresa</string>
+  <string name="input_url">Adresa Home Assistant-</string>
+  <string name="input_url_hint">https://example.duckdns.org:8123</string>
+  <string name="status_of_mobile_app_integration">Statusul integrării a l aplicatiei mobile.</string>
+  <string name="checking_with_home_assistant">Verific cu Home Assistant-ul</string>
+  <string name="skip">Nu acum </string>
+  <string name="retry">Reîncercați</string>
+  <string name="attempting_registration">Se încearcă înregistrarea aplicației...</string>
+  <string name="unable_to_register">Nu s-au putut înregistra </string>
+  <string name="error_with_registration">Te rog verifică dacă este activată integrarea pentru mobile_app în configurația Home Assistant-ului.</string>
+  <string name="url_parse_error">Nu am putut analiza adresa Home Assistant-ului. Ar trebui sa arate așa: https:///example.com</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,18 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
-    <string name="app_name">Home Assistant</string>
-    <string name="scanning_network">Scanning the network \nfor Home Assistant</string>
-    <string name="home_assistant_not_discover">Unable to find your \nHome Assistant instance</string>
-    <string name="connect_to_home_internet">Make sure your phone is connected \nto your home internet.</string>
-    <string name="scan_again">scan again</string>
-    <string name="manual_setup">enter address manually</string>
-    <string name="input_url">Home Assistant URL</string>
-    <string name="input_url_hint">https://example.duckdns.org:8123</string>
-    <string name="status_of_mobile_app_integration">Status of mobile app integration:</string>
-    <string name="checking_with_home_assistant">Checking with Home Assistant</string>
-    <string name="skip">Skip</string>
-    <string name="retry">Retry</string>
-    <string name="attempting_registration">Attempting to register application…</string>
-    <string name="unable_to_register">Unable to Register Application</string>
-    <string name="error_with_registration">Please check to ensure you have the mobile_app \nintegration enabled on your home assistant instance.</string>
-    <string name="url_parse_error">Unable to parse your Home Assistant URL. It should look like https://example.com</string>
+  <string name="app_name">Home Assistant</string>
+  <string name="scanning_network">Scanning the network 
+for Home Assistant</string>
+  <string name="home_assistant_not_discover">Unable to find your 
+Home Assistant instance</string>
+  <string name="connect_to_home_internet">Make sure your phone is connected 
+to your home internet.</string>
+  <string name="scan_again">scan again</string>
+  <string name="manual_setup">enter address manually</string>
+  <string name="input_url">Home Assistant URL</string>
+  <string name="input_url_hint">https://example.duckdns.org:8123</string>
+  <string name="status_of_mobile_app_integration">Status of mobile app integration:</string>
+  <string name="checking_with_home_assistant">Checking with Home Assistant</string>
+  <string name="skip">Skip</string>
+  <string name="retry">Retry</string>
+  <string name="attempting_registration">Attempting to register application…</string>
+  <string name="unable_to_register">Unable to Register Application</string>
+  <string name="error_with_registration">Please check to ensure you have the mobile_app 
+integration enabled on your home assistant instance.</string>
+  <string name="url_parse_error">Unable to parse your Home Assistant URL. It should look like https://example.com</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://maven.lokalise.co' }
     }
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 }


### PR DESCRIPTION
Adds the Lokalise SDK as [per their docs](https://docs.lokalise.com/en/articles/1400668-lokalise-android-sdk). Project ID and SDK token are baked in. SDK token is safe to be left in. It's in iOS as well.