### PR TITLE
Notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,9 @@ dependencies {
     implementation('com.lokalise.android:sdk:2.0.0-beta-2') { transitive = true }
 
     implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation "com.google.firebase:firebase-core:17.2.1"
+    implementation "com.google.firebase:firebase-iid:20.0.1"
+    implementation "com.google.firebase:firebase-messaging:20.0.1"
 
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek2Version"
     testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek2Version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,14 @@
         <activity android:name=".onboarding.OnboardingActivity" />
         <activity android:name=".webview.WebViewActivity" />
         <activity android:name=".settings.SettingsActivity" />
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_launcher_foreground" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/colorPrimary" />
+
     </application>
 
 </manifest>

--- a/data/src/main/java/io/homeassistant/companion/android/data/integration/RegisterDeviceRequest.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/integration/RegisterDeviceRequest.kt
@@ -15,5 +15,5 @@ data class RegisterDeviceRequest(
     var osVersion: String,
     var supportsEncryption: Boolean,
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    var appData: Dictionary<String, Objects>?
+    var appData: HashMap<String, String>?
 )

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/DeviceRegistration.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/DeviceRegistration.kt
@@ -13,5 +13,5 @@ data class DeviceRegistration(
     val osName: String,
     val osVersion: String,
     val supportsEncryption: Boolean,
-    val appData: Dictionary<String, Objects>?
+    val appData: HashMap<String, String>?
 )


### PR DESCRIPTION
I just got the very basic building blocks "done" even though this doesn't actually properly register the token to HA yet. Hoping someone else can help out to finish it up. The success point for this is being able to receive simple text only notifications. Extra credit if you implement any of the iOS features like custom sounds, inline images/camera stream/map or whatever. Full detail on those [here](https://companion.home-assistant.io/en/notifications/basic).

Things to do still:

- [ ] [Implement foreground receiving](https://firebase.google.com/docs/cloud-messaging/android/receive)
- [ ] Store push token somewhere so it can be sent as part of device registration and/or get the `FirebaseInstanceId.getInstance().instanceId` call working (I don't have a firm grasp on Kotlin co-routines yet, I'm sure someone a bit more competent can get it done quick!)
- [ ] Ensure we are listening for [new and updated tokens](https://firebase.google.com/docs/cloud-messaging/android/client#monitor-token-generation) and send to Home Assistant
- [ ] Adapt server side code as needed for Android (this is entirely on me, @robbiet480)

Fixes #7