### PR TITLE
Fix dialog button color in webview.

### DIFF
--- a/app/src/main/res/layout/fragment_manual_setup.xml
+++ b/app/src/main/res/layout/fragment_manual_setup.xml
@@ -32,6 +32,7 @@
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/ok"
+        style="@style/Widget.HomeAssistant.Button.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,8 +8,6 @@
 
         <item name="colorControlNormal">@android:color/white</item>
 
-        <item name="buttonStyle">@style/Widget.HomeAssistant.Button.Colored</item>
-
         <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert</item>
     </style>
 


### PR DESCRIPTION
This PR fixes bug with "no button" in dialog https://github.com/home-assistant/home-assistant-android/issues/90

Basically it's not a good idea to set button style globally for whole theme, it can lead to such issues. Better set it explicitly in layouts. 