### PR TITLE
Fix some styling

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        app:titleTextColor="@android:color/white"
+        android:theme="@style/Toolbar"
         android:elevation="4dp" />
     <FrameLayout
         android:id="@+id/content"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -8,7 +8,6 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
         android:theme="@style/ThemeOverlay.HomeAssistant.ActionBar"
         android:elevation="4dp" />
     <FrameLayout

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
-        android:theme="@style/Toolbar"
+        android:theme="@style/ThemeOverlay.HomeAssistant.ActionBar"
         android:elevation="4dp" />
     <FrameLayout
         android:id="@+id/content"

--- a/app/src/main/res/layout/fragment_manual_setup.xml
+++ b/app/src/main/res/layout/fragment_manual_setup.xml
@@ -14,14 +14,14 @@
         android:layout_height="wrap_content"
         app:helperText="@string/input_url_hint">
 
-        <androidx.appcompat.widget.AppCompatEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/home_assistant_url"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:hint="@string/input_url"
             android:imeOptions="actionDone"
-            android:inputType="text"
+            android:inputType="textUri"
             android:lines="1"
             android:maxLines="1" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#0288D1</color>
     <color name="colorAccent">#03A9F4</color>
+    <color name="onPrimary">@android:color/white</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,5 +3,5 @@
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#0288D1</color>
     <color name="colorAccent">#03A9F4</color>
-    <color name="onPrimary">@android:color/white</color>
+    <color name="colorOnPrimary">@android:color/white</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
     </style>
 
     <style name="Widget.HomeAssistant.Button.Colored" parent="Widget.MaterialComponents.Button">
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">@color/onPrimary</item>
     </style>
 
     <style name="Widget.HomeAssistant.Button.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
@@ -30,8 +30,9 @@
     </style>
 
     <style name="ThemeOverlay.HomeAssistant.ActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
-        <item name="android:textColorPrimary">@android:color/white</item>
-        <item name="colorControlNormal">@android:color/white</item>
+        <item name="android:background">@color/colorPrimary</item>
+        <item name="android:textColorPrimary">@color/onPrimary</item>
+        <item name="colorControlNormal">@color/onPrimary</item>
     </style>
 
     <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.Light.Dialog.Alert" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,7 +29,7 @@
         <item name="android:textColor">@color/colorPrimary</item>
     </style>
 
-    <style name="Toolbar">
+    <style name="ThemeOverlay.HomeAssistant.ActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="colorControlNormal">@android:color/white</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,8 +6,6 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorButtonNormal">@color/colorPrimary</item>
 
-        <item name="colorControlNormal">@android:color/white</item>
-
         <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert</item>
     </style>
 
@@ -29,6 +27,11 @@
 
     <style name="Widget.HomeAssistant.Button.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:textColor">@color/colorPrimary</item>
+    </style>
+
+    <style name="Toolbar">
+        <item name="android:textColorPrimary">@android:color/white</item>
+        <item name="colorControlNormal">@android:color/white</item>
     </style>
 
     <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.Light.Dialog.Alert" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
     </style>
 
     <style name="Widget.HomeAssistant.Button.Colored" parent="Widget.MaterialComponents.Button">
-        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textColor">@color/colorOnPrimary</item>
     </style>
 
     <style name="Widget.HomeAssistant.Button.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
@@ -31,8 +31,8 @@
 
     <style name="ThemeOverlay.HomeAssistant.ActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
         <item name="android:background">@color/colorPrimary</item>
-        <item name="android:textColorPrimary">@color/onPrimary</item>
-        <item name="colorControlNormal">@color/onPrimary</item>
+        <item name="android:textColorPrimary">@color/colorOnPrimary</item>
+        <item name="colorControlNormal">@color/colorOnPrimary</item>
     </style>
 
     <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.Light.Dialog.Alert" />


### PR DESCRIPTION
Because `colorControlNormal` was set to white, the underline of a inactive textbox would be white. Making it hard to see where to input text.

Before:
![Screenshot_2019-12-17-13-16-31-442_io homeassistant companion android](https://user-images.githubusercontent.com/5662298/70995035-d9a4d980-20cf-11ea-8a60-36b941f0fcd6.jpg)
After:
![Screenshot_2019-12-17-13-17-38-500_io homeassistant companion android](https://user-images.githubusercontent.com/5662298/70995036-da3d7000-20cf-11ea-91eb-df7acc020172.jpg)

(nice and big screenshots 👎 )