### PR TITLE
[CI] Version Code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: android
 dist: trusty
 
+git:
+  depth: false
+
 before_install:
   - chmod ugo+x .travis/before_install.sh
   - ./.travis/before_install.sh


### PR DESCRIPTION
The version code base on the commit number is not compatible with depth clone (The version code is stuck at 50)
`git clone --depth=50 --branch=master https://github.com/home-assistant/home-assistant-android.git `
https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
