### PR TITLE
Open urls that are outside the application correctly.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -89,6 +89,17 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                     Log.e(TAG, "onReceivedHttpError: $error")
                     showError()
                 }
+
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    request?.url?.let {
+                        val browserIntent = Intent(Intent.ACTION_VIEW, it)
+                        startActivity(browserIntent)
+                    }
+                    return true
+                }
             }
 
             webChromeClient = object : WebChromeClient() {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -95,10 +95,13 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                     request: WebResourceRequest?
                 ): Boolean {
                     request?.url?.let {
-                        val browserIntent = Intent(Intent.ACTION_VIEW, it)
-                        startActivity(browserIntent)
+                        if (!it.toString().contains(webView.url.toString())) {
+                            val browserIntent = Intent(Intent.ACTION_VIEW, it)
+                            startActivity(browserIntent)
+                            return true
+                        }
                     }
-                    return true
+                    return false
                 }
             }
 
@@ -140,15 +143,15 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                         when {
                             JSONObject(message).get("type") == "config/get" -> {
                                 val script = "externalBus(" +
-                                    "${JSONObject(
-                                        mapOf(
-                                            "id" to JSONObject(message).get("id"),
-                                            "type" to "result",
-                                            "success" to true,
-                                            "result" to JSONObject(mapOf("hasSettingsScreen" to true))
-                                        )
-                                    )}" +
-                                    ");"
+                                        "${JSONObject(
+                                            mapOf(
+                                                "id" to JSONObject(message).get("id"),
+                                                "type" to "result",
+                                                "success" to true,
+                                                "result" to JSONObject(mapOf("hasSettingsScreen" to true))
+                                            )
+                                        )}" +
+                                        ");"
                                 Log.d(TAG, script)
                                 webView.evaluateJavascript(script) {
                                     Log.d(TAG, "Callback $it")


### PR DESCRIPTION
Fixes: https://github.com/home-assistant/home-assistant-android/issues/75
Fixes: https://github.com/home-assistant/home-assistant-android/issues/117

After some testing I didn't see any calls to ```shouldOverrideUrlLoading``` from the application itself.  It appeared that all calls to this method are ones that we should let the OS handle not the webview.