### PR TITLE
Add the ability to debug on same device as production application.

### DIFF
--- a/.travis/mock-google-services.json
+++ b/.travis/mock-google-services.json
@@ -18,6 +18,19 @@
           "current_key": "current_key"
         }
       ]
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "mobilesdk_app_id",
+        "android_client_info": {
+          "package_name": "io.homeassistant.companion.android.debug"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": "current_key"
+        }
+      ]
     }
   ],
   "configuration_version": "1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             debuggable false
             jniDebuggable false


### PR DESCRIPTION
This will allow developers to have both a local debug version of app and a production like instance of the application on device at the same time.  Making it easier to test multiple devices.