### PR TITLE
Replacing equality for `contains` to Home Network WiFi SSID (#250)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@ integration enabled on your home assistant instance.</string>
     <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again.</string>
     <string name="pref_connection_title">Connection Information</string>
     <string name="pref_connection_url">Home Assistant URL</string>
-    <string name="pref_connection_wifi">Home Network WiFi SSID</string>
+    <string name="pref_connection_wifi">Home Network WiFi SSID contains</string>
     <string name="pref_connection_internal">Internal Connection URL</string>
     <string name="url_invalid">Url Invalid</string>
     <string name="error_auth_revoked">It appears that your authorization was revoked, please reconnect to Home Assistant.</string>

--- a/data/src/main/java/io/homeassistant/companion/android/data/url/UrlRepositoryImpl.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/url/UrlRepositoryImpl.kt
@@ -102,6 +102,6 @@ class UrlRepositoryImpl @Inject constructor(
 
     private suspend fun isInternal(): Boolean {
         return !localStorage.getString(PREF_LOCAL_URL).isNullOrBlank() &&
-                wifiHelper.getWifiSsid() == "\"${getHomeWifiSsid()}\""
+                wifiHelper.getWifiSsid().contains(getHomeWifiSsid().toString())
     }
 }


### PR DESCRIPTION
This implementation is a proposal for #250. The desired implementation for the issue was to have a list to edit like the iOS app. However, the issue is that some places have more than one access point with a different SSID name and most of the cases the names share a common name. This is why I suggest this implementation to check if the connected wifi contains the text inputted from the app configuration, instead of checking equality.

I changed from `"\"${getHomeWifiSsid()}\""`  to `getHomeWifiSsid().toString()` since the first one did not work on my phone.

This was tested on my Samsung S9. I added the shared name of my APs on the app and it connected to the internal URL for all my APs.