### PR TITLE
Add FullScreen/Hide Navigation Bar

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -47,7 +47,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
         val onChangeSwitchFullScreen = Preference.OnPreferenceChangeListener { _, newValue ->
             if (newValue == true)
                 findPreference<SwitchPreference>("hide_nav")?.let {
-                 it.isChecked = false
+                    it.isChecked = false
                 }
             true
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -44,6 +44,22 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
             isValid
         }
 
+        val onChangeSwitchFullScreen = Preference.OnPreferenceChangeListener { _, newValue ->
+            if (newValue == true)
+                findPreference<SwitchPreference>("hide_nav")?.let {
+                 it.isChecked = false
+                }
+            true
+        }
+
+        val onChangeSwitchHideNavigation = Preference.OnPreferenceChangeListener { _, newValue ->
+            if (newValue == true)
+                findPreference<SwitchPreference>("fullscreen")?.let {
+                    it.isChecked = false
+                }
+            true
+        }
+
         findPreference<EditTextPreference>("connection_internal")?.onPreferenceChangeListener =
             onChangeUrlValidator
 
@@ -53,6 +69,12 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
         findPreference<Preference>("version")?.let {
             it.summary = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
         }
+
+        findPreference<SwitchPreference>("fullscreen")?.onPreferenceChangeListener =
+            onChangeSwitchFullScreen
+
+        findPreference<SwitchPreference>("hide_nav")?.onPreferenceChangeListener =
+            onChangeSwitchHideNavigation
 
         presenter.onCreate()
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -29,6 +29,8 @@ class SettingsPresenterImpl @Inject constructor(
             return@runBlocking when (key) {
                 "location_zone" -> integrationUseCase.isZoneTrackingEnabled()
                 "location_background" -> integrationUseCase.isBackgroundTrackingEnabled()
+                "fullscreen" -> integrationUseCase.isFullScreenEnabled()
+                "hide_nav" -> integrationUseCase.isHideNavigationBarEnabled()
                 else -> throw Exception()
             }
         }
@@ -39,6 +41,8 @@ class SettingsPresenterImpl @Inject constructor(
             when (key) {
                 "location_zone" -> integrationUseCase.setZoneTrackingEnabled(value)
                 "location_background" -> integrationUseCase.setBackgroundTrackingEnabled(value)
+                "fullscreen" -> integrationUseCase.setFullScreenEnabled(value)
+                "hide_nav" -> integrationUseCase.setHideNavigationBarEnabled(value)
                 else -> throw Exception()
             }
             settingsView.onLocationSettingChanged()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import android.view.MenuInflater
+import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.JsResult
 import android.webkit.PermissionRequest
@@ -226,13 +227,44 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                 }
             }, "externalApp")
         }
+
+        window.decorView.setOnSystemUiVisibilityChangeListener { visibility ->
+            if (visibility and View.SYSTEM_UI_FLAG_FULLSCREEN == 0)
+                if (presenter.isFullScreen())
+                    hideSystemUI()
+                else if (presenter.isHideNavigationBar())
+                    window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+        }
+
+        presenter.onViewReady()
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) {
             presenter.onViewReady()
+            if (presenter.isFullScreen())
+                hideSystemUI()
+            else if (presenter.isHideNavigationBar())
+                window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+            else
+                showSystemUI()
         }
+    }
+
+    private fun hideSystemUI() {
+        window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+    }
+
+    private fun showSystemUI() {
+        window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
     }
 
     override fun attachBaseContext(newBase: Context) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -10,5 +10,9 @@ interface WebViewPresenter {
 
     fun clearKnownUrls()
 
+    fun isFullScreen(): Boolean
+
+    fun isHideNavigationBar(): Boolean
+
     fun onFinish()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 class WebViewPresenterImpl @Inject constructor(
     private val view: WebView,
@@ -88,6 +89,18 @@ class WebViewPresenterImpl @Inject constructor(
         mainScope.launch {
             urlUseCase.saveUrl("", true)
             urlUseCase.saveUrl("", false)
+        }
+    }
+
+    override fun isFullScreen(): Boolean {
+        return runBlocking {
+            integrationUseCase.isFullScreenEnabled()
+        }
+    }
+
+    override fun isHideNavigationBar(): Boolean {
+        return runBlocking {
+            integrationUseCase.isHideNavigationBarEnabled()
         }
     }
 

--- a/app/src/main/res/drawable/ic_fullscreen.xml
+++ b/app/src/main/res/drawable/ic_fullscreen.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M7,14L5,14v5h5v-2L7,17v-3zM5,10h2L7,7h3L10,5L5,5v5zM17,17h-3v2h5v-5h-2v3zM14,5v2h3v3h2L19,5h-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_hide_navigation.xml
+++ b/app/src/main/res/drawable/ic_hide_navigation.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/colorAccent"
+      android:pathData="M7,14h-2v5h5v-2h-3v-3ZM5,10h2v-3h3v-2h-5v5ZM17,17h-3v2h5v-5h-2v3ZM14,5v2h3v3h2v-5h-5Z"/>
+  <path
+      android:pathData="M10.3824,5.5h3.1765v1h-3.1765z"
+      android:strokeWidth="1"
+      android:fillColor="@color/colorAccent"
+      android:strokeColor="@color/colorAccent"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,9 @@ integration enabled on your home assistant instance.</string>
     <string name="permission_explanation">In order to use location tracking features or different connection urls based on WiFi SSID we need access to your location. If you want consistent background updates you will also need to allow background processing</string>
     <string name="grant_permission">Grant Permission</string>
     <string name="finish">Finish</string>
+    <string name="other_settings">Other Settings</string>
+    <string name="fullscreen">Fullscreen</string>
+    <string name="fullscreen_def">Put application in full screen</string>
+    <string name="hide_nav">Hide Navigation Bar</string>
+    <string name="hide_nav_def">Hide only navigation bar</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.HomeAssistant" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorButtonNormal">@color/colorPrimary</item>
-
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="27">shortEdges</item>
         <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert</item>
     </style>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,6 +38,19 @@
             android:summary="@string/pref_location_background_summary"/>
     </PreferenceCategory>
     <PreferenceCategory
+        android:title="@string/fullscreen">
+        <SwitchPreference
+            android:key="fullscreen"
+            android:icon="@drawable/ic_fullscreen"
+            android:title="@string/fullscreen"
+            android:summary="@string/fullscreen_def"/>
+        <SwitchPreference
+            android:key="hide_nav"
+            android:icon="@drawable/ic_hide_navigation"
+            android:title="@string/hide_nav"
+            android:summary="@string/hide_nav_def"/>
+    </PreferenceCategory>
+    <PreferenceCategory
         android:title="@string/app_version_info">
         <Preference
             android:key="version"

--- a/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
@@ -37,6 +37,8 @@ class IntegrationRepositoryImpl @Inject constructor(
 
         private const val PREF_ZONE_ENABLED = "zone_enabled"
         private const val PREF_BACKGROUND_ENABLED = "background_enabled"
+        private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
+        private const val PREF_HIDENAVBAR_ENABLED = "hide_navigation_bar_enabled"
     }
 
     override suspend fun registerDevice(deviceRegistration: DeviceRegistration) {
@@ -181,6 +183,22 @@ class IntegrationRepositoryImpl @Inject constructor(
 
     override suspend fun isBackgroundTrackingEnabled(): Boolean {
         return localStorage.getBoolean(PREF_BACKGROUND_ENABLED)
+    }
+
+    override suspend fun setFullScreenEnabled(enabled: Boolean) {
+        localStorage.putBoolean(PREF_FULLSCREEN_ENABLED, enabled)
+    }
+
+    override suspend fun isFullScreenEnabled(): Boolean {
+        return localStorage.getBoolean(PREF_FULLSCREEN_ENABLED)
+    }
+
+    override suspend fun setHideNavigationBarEnabled(enabled: Boolean) {
+        localStorage.putBoolean(PREF_HIDENAVBAR_ENABLED, enabled)
+    }
+
+    override suspend fun isHideNavigationBarEnabled(): Boolean {
+        return localStorage.getBoolean(PREF_HIDENAVBAR_ENABLED)
     }
 
     override suspend fun getThemeColor(): String {

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationRepository.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationRepository.kt
@@ -21,4 +21,10 @@ interface IntegrationRepository {
     suspend fun getThemeColor(): String
 
     suspend fun callService(domain: String, service: String, serviceData: HashMap<String, Any>)
+
+    suspend fun setFullScreenEnabled(enabled: Boolean)
+    suspend fun isFullScreenEnabled(): Boolean
+
+    suspend fun setHideNavigationBarEnabled(enabled: Boolean)
+    suspend fun isHideNavigationBarEnabled(): Boolean
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCase.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCase.kt
@@ -29,4 +29,10 @@ interface IntegrationUseCase {
     suspend fun isBackgroundTrackingEnabled(): Boolean
 
     suspend fun getThemeColor(): String
+
+    suspend fun setFullScreenEnabled(enabled: Boolean)
+    suspend fun isFullScreenEnabled(): Boolean
+
+    suspend fun setHideNavigationBarEnabled(enabled: Boolean)
+    suspend fun isHideNavigationBarEnabled(): Boolean
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
@@ -67,4 +67,20 @@ class IntegrationUseCaseImpl @Inject constructor(
     override suspend fun getThemeColor(): String {
         return integrationRepository.getThemeColor()
     }
+
+    override suspend fun setFullScreenEnabled(enabled: Boolean) {
+        return integrationRepository.setFullScreenEnabled(enabled)
+    }
+
+    override suspend fun isFullScreenEnabled(): Boolean {
+        return integrationRepository.isFullScreenEnabled()
+    }
+
+    override suspend fun setHideNavigationBarEnabled(enabled: Boolean) {
+        return integrationRepository.setHideNavigationBarEnabled(enabled)
+    }
+
+    override suspend fun isHideNavigationBarEnabled(): Boolean {
+        return integrationRepository.isHideNavigationBarEnabled()
+    }
 }


### PR DESCRIPTION
Forgot to test if fullscreen is set or not in setOnSystemuiVisiblityChangeListener (line 231 in WebViewActivity.kt). This listener allows to keep the full screen even after using the virtual keyboard. Without testing the isFullscreen () condition, it always puts the application in full screen, even if the option is not activated.

And add new setting for just hide navigation bar :

![Screenshot_20200124-121520_Home Assistant](https://user-images.githubusercontent.com/45233613/73065225-58491f80-3ea3-11ea-8045-436feb510c0d.jpg)

And as requested all in one commit (almost... one missed indentation in a file... )
