### PR TITLE
Add note to check companion docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -6,6 +6,7 @@ about: Create a report to help us improve
 <!-- READ THIS FIRST:
 - Make sure you run the latest version of the Android app
 - Make sure you run the latest version of Home Assistant
+- Make sure to check the Companion docs for troubleshooting and configuration: https://companion.home-assistant.io/
 -->
 
 **Home Assistant Android version:**


### PR DESCRIPTION
Now that we have some type of documentation we should direct users to check the docs for troubleshooting and configuration :)

Still got more to add but there is some guidance now to help with issues.