### PR TITLE
Moved JSON to HashMap cast into try-catch block

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
@@ -166,11 +166,11 @@ class ButtonWidget : AppWidgetProvider() {
                 Log.w(TAG, "Service Call Data incomplete.  Aborting service call")
             } else {
                 // If everything loaded correctly, package the service data and attempt the call
-
-                // Convert JSON to HashMap
-                val serviceDataMap = Gson().fromJson(serviceDataJson, HashMap<String, Any>()::class.java)
-
                 try {
+                    // Convert JSON to HashMap
+                    val serviceDataMap =
+                        Gson().fromJson(serviceDataJson, HashMap<String, Any>()::class.java)
+
                     integrationUseCase.callService(domain, service, serviceDataMap)
 
                     // If service call does not throw an exception, send positive feedback


### PR DESCRIPTION
This is a potential fix for #365.  The crashing in that issue seems to be caused by the old widget service data string being loaded if the widgets were created pre-1.6.0, when the service data changed from being stored as a plain string that was assigned to `entity_id` to a JSON string that could handle multiple fields, not just `entity_id`.

Instead of just crashing, the widget will fail and display the "red X" negative feedback.