### PR TITLE
Allow expandable notifications for long text messages.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -179,6 +179,8 @@ class MessagingService : FirebaseMessagingService() {
         builder
             .setContentTitle(data[TITLE])
             .setContentText(data[MESSAGE])
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText(data[MESSAGE]))
     }
 
     private suspend fun handleImage(


### PR DESCRIPTION
Proposed resolution for #372 to add support for a large text box in the notification if the message length exceeds one line.

Reference: https://developer.android.com/training/notify-user/expanded#large-style

Please note: I was unable to figure out how to test notifications from the debug app through Android Studio using my own Firebase config. I'll reach out on Discord, but if anyone on here can point me in the right direction, I'd appreciate it.