### PR TITLE
Reworked widget appearance and added resizability.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
@@ -139,8 +139,8 @@ class ButtonWidget : AppWidgetProvider() {
             RemoteViews(context.packageName, R.layout.widget_button)
         val appWidgetManager = AppWidgetManager.getInstance(context)
 
-        loadingViews.setInt(R.id.widgetProgressBar, "setVisibility", View.VISIBLE)
-        loadingViews.setInt(R.id.widgetImageButtonLayout, "setVisibility", View.INVISIBLE)
+        loadingViews.setViewVisibility(R.id.widgetProgressBar, View.VISIBLE)
+        loadingViews.setViewVisibility(R.id.widgetImageButtonLayout, View.GONE)
         appWidgetManager.partiallyUpdateAppWidget(appWidgetId, loadingViews)
 
         mainScope.launch {
@@ -185,9 +185,9 @@ class ButtonWidget : AppWidgetProvider() {
             // Update widget and set visibilities for feedback
             views.setInt(R.id.widgetLayout, "setBackgroundResource", feedbackColor)
             views.setImageViewResource(R.id.widgetImageButton, feedbackIcon)
-            views.setInt(R.id.widgetProgressBar, "setVisibility", View.INVISIBLE)
-            views.setInt(R.id.widgetLabel, "setVisibility", View.GONE)
-            views.setInt(R.id.widgetImageButtonLayout, "setVisibility", View.VISIBLE)
+            views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
+            views.setViewVisibility(R.id.widgetLabelLayout, View.GONE)
+            views.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
             appWidgetManager.updateAppWidget(appWidgetId, views)
 
             // Reload default views in the coroutine to pass to the post handler
@@ -195,7 +195,7 @@ class ButtonWidget : AppWidgetProvider() {
 
             // Set a timer to change it back after 1 second
             Handler().postDelayed({
-                views.setInt(R.id.widgetLabel, "setVisibility", View.VISIBLE)
+                views.setViewVisibility(R.id.widgetLabelLayout, View.VISIBLE)
                 views.setInt(
                     R.id.widgetLayout,
                     "setBackgroundResource",

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
@@ -113,7 +113,7 @@ class ButtonWidget : AppWidgetProvider() {
                 icon
             )
             setOnClickPendingIntent(
-                R.id.widgetImageButton,
+                R.id.widgetImageButtonLayout,
                 PendingIntent.getBroadcast(
                     context,
                     appWidgetId,
@@ -135,11 +135,12 @@ class ButtonWidget : AppWidgetProvider() {
 
         // Set up progress bar as immediate feedback to show the click has been received
         // Success or failure feedback will come from the mainScope coroutine
-        val loadingViews: RemoteViews = RemoteViews(context.packageName, R.layout.widget_button)
+        val loadingViews: RemoteViews =
+            RemoteViews(context.packageName, R.layout.widget_button)
         val appWidgetManager = AppWidgetManager.getInstance(context)
 
         loadingViews.setInt(R.id.widgetProgressBar, "setVisibility", View.VISIBLE)
-        loadingViews.setInt(R.id.widgetImageButton, "setVisibility", View.INVISIBLE)
+        loadingViews.setInt(R.id.widgetImageButtonLayout, "setVisibility", View.INVISIBLE)
         appWidgetManager.partiallyUpdateAppWidget(appWidgetId, loadingViews)
 
         mainScope.launch {
@@ -147,7 +148,7 @@ class ButtonWidget : AppWidgetProvider() {
             var views = getWidgetRemoteViews(context, appWidgetId)
 
             // Set default feedback as negative
-            var feedbackColor = R.drawable.ic_circle_red_24dp
+            var feedbackColor = R.drawable.widget_button_background_red
             var feedbackIcon = R.drawable.ic_clear_black_24dp
 
             // Load the service call data from Shared Preferences
@@ -174,18 +175,19 @@ class ButtonWidget : AppWidgetProvider() {
                     integrationUseCase.callService(domain, service, serviceDataMap)
 
                     // If service call does not throw an exception, send positive feedback
-                    feedbackColor = R.drawable.ic_circle_green_24dp
+                    feedbackColor = R.drawable.widget_button_background_green
                     feedbackIcon = R.drawable.ic_check_black_24dp
                 } catch (e: Exception) {
                     Log.e(TAG, "Could not send service call.", e)
                 }
             }
 
-            // Update widget with feedback and reset visibilities
-            views.setImageViewResource(R.id.widgetImageButtonBackground, feedbackColor)
+            // Update widget and set visibilities for feedback
+            views.setInt(R.id.widgetLayout, "setBackgroundResource", feedbackColor)
             views.setImageViewResource(R.id.widgetImageButton, feedbackIcon)
             views.setInt(R.id.widgetProgressBar, "setVisibility", View.INVISIBLE)
-            views.setInt(R.id.widgetImageButton, "setVisibility", View.VISIBLE)
+            views.setInt(R.id.widgetLabel, "setVisibility", View.GONE)
+            views.setInt(R.id.widgetImageButtonLayout, "setVisibility", View.VISIBLE)
             appWidgetManager.updateAppWidget(appWidgetId, views)
 
             // Reload default views in the coroutine to pass to the post handler
@@ -193,9 +195,11 @@ class ButtonWidget : AppWidgetProvider() {
 
             // Set a timer to change it back after 1 second
             Handler().postDelayed({
-                views.setImageViewResource(
-                    R.id.widgetImageButtonBackground,
-                    R.drawable.ic_circle_white_24dp
+                views.setInt(R.id.widgetLabel, "setVisibility", View.VISIBLE)
+                views.setInt(
+                    R.id.widgetLayout,
+                    "setBackgroundResource",
+                    R.drawable.widget_button_background_white
                 )
                 appWidgetManager.updateAppWidget(appWidgetId, views)
             }, 1000)

--- a/app/src/main/res/drawable/ic_circle_green_24dp.xml
+++ b/app/src/main/res/drawable/ic_circle_green_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF00FF00"
-        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_circle_red_24dp.xml
+++ b/app/src/main/res/drawable/ic_circle_red_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FFFF0000"
-        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_circle_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_circle_white_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
-</vector>

--- a/app/src/main/res/drawable/widget_button_background_green.xml
+++ b/app/src/main/res/drawable/widget_button_background_green.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FF00FF00"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/widget_button_background_red.xml
+++ b/app/src/main/res/drawable/widget_button_background_red.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFFF0000"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/drawable/widget_button_background_white.xml
+++ b/app/src/main/res/drawable/widget_button_background_white.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFFFFFFF"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -25,6 +25,7 @@
             />
 
         <LinearLayout
+            android:id="@+id/widgetLabelLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="2dp"

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -1,58 +1,57 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widgetLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:minHeight="40dp"
     android:minWidth="40dp"
-    android:orientation="vertical"
-    android:padding="@dimen/widget_margin">
+    android:background="@drawable/widget_button_background_white"
+    android:padding="4dp">
 
-    <FrameLayout
-        android:id="@+id/widgetImageButtonFrameLayout"
+    <LinearLayout
+        android:id="@+id/widgetImageButtonLayout"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <ImageView
-            android:id="@+id/widgetImageButtonBackground"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="0dp"
-            android:contentDescription="@string/widget_image_description"
-            android:src="@drawable/ic_circle_white_24dp"
-            android:scaleType="fitCenter"
-            />
-
-        <ImageButton
             android:id="@+id/widgetImageButton"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="0dp"
-            android:contentDescription="@string/widget_image_description"
-            android:background="@null"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:src="@drawable/ic_flash_on_black_24dp"
-            android:scaleType="centerInside"
-            android:adjustViewBounds="true"
+            android:contentDescription="@string/widget_image_description"
+            android:gravity="center"
             />
 
-        <ProgressBar
-            android:id="@+id/widgetProgressBar"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="8dp"
-            android:visibility="invisible"
-            android:indeterminate="true"
-            android:indeterminateTint="@color/colorAccent"
-            />
-    </FrameLayout>
+            android:layout_height="wrap_content"
+            android:layout_margin="2dp"
+            android:minHeight="32sp">
 
-    <TextView
-        android:id="@+id/widgetLabel"
+            <TextView
+                android:id="@+id/widgetLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/widget_label_placeholder_text"
+                android:textSize="12sp"
+                android:textAlignment="center"
+                android:gravity="center"
+                android:minLines="1"
+                android:maxLines="2"
+                />
+        </LinearLayout>
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/widgetProgressBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="0dp"
-        android:textAlignment="center"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/colorOnPrimary"
-        android:textSize="12sp" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        android:padding="8dp"
+        android:visibility="invisible"
+        android:indeterminate="true"
+        android:indeterminateTint="@color/colorAccent"
+        />
+</FrameLayout>

--- a/app/src/main/res/xml/button_widget_info.xml
+++ b/app/src/main/res/xml/button_widget_info.xml
@@ -5,5 +5,8 @@
     android:initialLayout="@layout/widget_button"
     android:minWidth="40dp"
     android:minHeight="40dp"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
+    android:resizeMode="vertical|horizontal"
     android:updatePeriodMillis="86400000"
     android:widgetCategory="home_screen" />


### PR DESCRIPTION
I have reworked the appearance of the widgets to not look like app icons.  They're a bit clunkier (imho), but will not be confused with app icons as in #299.  The widgets are also resizeable, though it just increases the size of the icon and doesn't actually add any functionality.  It does mean you can create more "bar"-like icons rather than just square/rectangular buttons.

This also allows for quite a bit more text -- I know the initial design was not great for the amount of text you could put, but this should allow quite a bit more, even without resizing.

Oh, and unlike the last large widget update, this is backwards-compatible and will not break old widgets - when the app updates, they'll just update their shapes.

If it's not obvious, I don't have a ton of graphic design sense, so this is really the best I can do, visually.  If someone else wants to propose a prettier alternative, I would love to see it.

Addresses #299 and (kinda) addresses #363, though not in a real sense for the latter.  I'd' have to be given a direction to go in to create a widget with different functionality, since I am not sure what other people would like to have. This technically can be resized to bigger, though.

Images of a sample home screen are below (SDK 24).  I have also tested on Nova Launcher on Android 9.
<img width="204" alt="Capture1" src="https://user-images.githubusercontent.com/8548596/74381694-f13fcc00-4db9-11ea-8499-f0dcac87df06.png">

Image of pressed button displaying failure feedback:
<img width="82" alt="Capture2" src="https://user-images.githubusercontent.com/8548596/74381747-07e62300-4dba-11ea-9e9d-6ff16a757a46.png">
(I don't have a successful feedback image, but if you really need one I can get one)
