### PR TITLE
Added catch blocks for bad custom component service data responses

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/WidgetDynamicFieldAdapter.kt
@@ -64,14 +64,14 @@ class WidgetDynamicFieldAdapter(
             // Only populate with entities for the domain
             // or for homeassistant domain, which should be able
             // to manipulate entities in any domain
-            val domain = services[serviceText]!!.domain
+            val domain = services[serviceText]?.domain
 
             // Add all as an available entity
             // all is a special keyword, so it won't be listed in any
             // domains even though it is available for all of them
             domainEntities.add("all")
 
-            if (domain == ("homeassistant")) {
+            if (domain == ("homeassistant") || domain == null) {
                 domainEntities.addAll(entities.keys)
             } else {
                 entities.keys.forEach {
@@ -85,12 +85,12 @@ class WidgetDynamicFieldAdapter(
             adapter.addAll(domainEntities.sorted().toMutableList())
             autoCompleteTextView.setAdapter(adapter)
             autoCompleteTextView.onFocusChangeListener = dropDownOnFocus
-        } else if (services[serviceText]!!.serviceData.fields[fieldKey]!!.values != null) {
+        } else if (services[serviceText]?.serviceData?.fields?.get(fieldKey)?.values != null) {
             // If a non-"entity_id" field has specific values,
             // populate the autocomplete with valid values
             val fieldAdapter = SingleItemArrayAdapter<String>(context) { it!! }
             fieldAdapter.addAll(
-                services[serviceText]!!.serviceData.fields[fieldKey]!!.values!!.sorted().toMutableList()
+                services[serviceText]!!.serviceData.fields.getValue(fieldKey).values!!.sorted().toMutableList()
             )
             autoCompleteTextView.setAdapter(fieldAdapter)
             autoCompleteTextView.onFocusChangeListener = dropDownOnFocus

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -40,10 +40,28 @@
                 android:inputType="text" />
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/widget_config_service_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:textSize="14sp"
+            android:text="@string/widget_config_service_error"
+            android:visibility="gone" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/widget_config_fields_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/add_field_button"
+            style="@style/Widget.HomeAssistant.Button.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:text="@string/add_service_data_field" />
 
         <LinearLayout
             android:id="@+id/widget_config_icon_layout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="configure_service_call">Configure Service Call</string>
     <string name="configure_widget_label">Widget Label</string>
     <string name="add_widget">Add widget</string>
+    <string name="add_service_data_field">Add Field</string>
+    <string name="widget_config_service_error">A custom component is preventing service data from loading.</string>
     <string name="widget_text_hint_service_domain">Domain</string>
     <string name="widget_text_hint_service_service">Service</string>
     <string name="widget_text_hint_service_data">Entity ID</string>


### PR DESCRIPTION
See related conversation in #406.

These try/catch blocks should stop the widget configuration activity from crashing if a custom component with an incorrect `services.yaml` configuration is sent as a response to the integration services request.  Most of the additional changes in the `WidgetDynamicFieldAdapter.kt` file are accounting for the fact that `services` and `entities` might be empty.

In case the services fail to load, an error message is displayed for the user to indicate that services have failed to load.  This message does not show up if entities fail to load.

Also, a new `Add Field` button with associated AlertBox dialog has been created.  It will create a custom field and associated value input. _After you create the field, if you change the text of the service, it will remove that custom created box._