### PR TITLE
Add Dim Screen & Keep Screen On 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:ignore="ProtectedPermissions" />
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -55,6 +55,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "connection_internal_wifi" -> urlUseCase.getHomeWifiSsid()
                 "connection_external" -> (urlUseCase.getUrl(false) ?: "").toString()
                 "registration_name" -> integrationUseCase.getRegistration().deviceName
+                "dim_screen" -> integrationUseCase.getDimTimeOut()
                 else -> throw Exception()
             }
         }
@@ -79,6 +80,9 @@ class SettingsPresenterImpl @Inject constructor(
                     } catch (e: Exception) {
                         Log.e(TAG, "Issue updating registration with new device name", e)
                     }
+                }
+                "dim_screen" -> {
+                    integrationUseCase.setDimTimeOut(value)
                 }
                 else -> throw Exception()
             }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -38,8 +38,8 @@ import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.sensors.SensorWorker
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.util.PermissionManager
-import okhttp3.internal.toNonNegativeInt
 import javax.inject.Inject
+import okhttp3.internal.toNonNegativeInt
 import org.json.JSONObject
 
 class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.webview.WebView {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -59,7 +59,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private lateinit var webView: WebView
     private lateinit var loadedUrl: String
     private lateinit var dimHandler: Handler
-    private lateinit var dimRunnable:Runnable
+    private lateinit var dimRunnable: Runnable
 
     private var isConnected = false
     private var isShowingError = false

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -12,5 +12,7 @@ interface WebViewPresenter {
 
     fun isFullScreen(): Boolean
 
+    fun getDimTimeOut(): String?
+
     fun onFinish()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -98,6 +98,12 @@ class WebViewPresenterImpl @Inject constructor(
         }
     }
 
+    override fun getDimTimeOut(): String? {
+        return runBlocking {
+            integrationUseCase.getDimTimeOut()
+        }
+    }
+
     override fun onFinish() {
         mainScope.cancel()
     }

--- a/app/src/main/res/drawable/ic_brightness.xml
+++ b/app/src/main/res/drawable/ic_brightness.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M20,15.31L23.31,12 20,8.69V4h-4.69L12,0.69 8.69,4H4v4.69L0.69,12 4,15.31V20h4.69L12,23.31 15.31,20H20v-4.69zM12,18V6c3.31,0 6,2.69 6,6s-2.69,6 -6,6z"/>
+</vector>

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -2,4 +2,5 @@
 <WebView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/webview"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:keepScreenOn="true" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="password">Password</string>
     <string name="auth_request">Authentication Requested:</string>
     <string name="auth_cancel">Authentication Cancelled</string>
-    <string name="dim_screen">Screen Brightness TimeOut (in sec, 0 or empty for no timeout)</string>
+    <string name="dim_screen">Dim Screen TimeOut (in sec, 0 or empty for no timeout)</string>
     <string name="write_request_title">System App Requested</string>
     <string name="write_request_message">For this function, app require write access, do you grant it ?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,6 @@
     <string name="auth_request">Authentication Requested:</string>
     <string name="auth_cancel">Authentication Cancelled</string>
     <string name="dim_screen">Dim Screen TimeOut (in sec, 0 or empty for no timeout)</string>
-    <string name="write_request_title">System App Requested</string>
-    <string name="write_request_message">For this function, app require write access, do you grant it ?</string>
+    <string name="write_request_title">System Settings Access Requested</string>
+    <string name="write_request_message">For this function, app require write access, want you grant it ?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,7 @@
     <string name="password">Password</string>
     <string name="auth_request">Authentication Requested:</string>
     <string name="auth_cancel">Authentication Cancelled</string>
+    <string name="dim_screen">Screen Brightness TimeOut (in sec, 0 or empty for no timeout)</string>
+    <string name="write_request_title">System App Requested</string>
+    <string name="write_request_message">For this function, app require write access, do you grant it ?</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,6 +44,11 @@
             android:icon="@drawable/ic_fullscreen"
             android:title="@string/fullscreen"
             android:summary="@string/fullscreen_def"/>
+        <EditTextPreference
+            android:key="dim_screen"
+            android:icon="@drawable/ic_brightness"
+            android:title="@string/dim_screen"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/app_version_info">

--- a/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
@@ -22,6 +22,7 @@ import io.homeassistant.companion.android.domain.url.UrlRepository
 import javax.inject.Inject
 import javax.inject.Named
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.internal.http2.Settings
 
 class IntegrationRepositoryImpl @Inject constructor(
     private val integrationService: IntegrationService,
@@ -50,6 +51,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_BACKGROUND_ENABLED = "background_enabled"
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
         private const val PREF_SENSORS_REGISTERED = "sensors_registered"
+        private const val PREF_DIM_TIMEOUT = "0"
     }
 
     override suspend fun registerDevice(deviceRegistration: DeviceRegistration) {
@@ -407,5 +409,13 @@ class IntegrationRepositoryImpl @Inject constructor(
         }
 
         return retVal.toTypedArray()
+    }
+
+    override suspend fun getDimTimeOut(): String? {
+        return localStorage.getString(PREF_DIM_TIMEOUT)
+    }
+
+    override suspend fun setDimTimeOut(time: String?) {
+        localStorage.putString(PREF_DIM_TIMEOUT, time)
     }
 }

--- a/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/integration/IntegrationRepositoryImpl.kt
@@ -22,7 +22,6 @@ import io.homeassistant.companion.android.domain.url.UrlRepository
 import javax.inject.Inject
 import javax.inject.Named
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.internal.http2.Settings
 
 class IntegrationRepositoryImpl @Inject constructor(
     private val integrationService: IntegrationService,

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationRepository.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationRepository.kt
@@ -33,4 +33,7 @@ interface IntegrationRepository {
 
     suspend fun registerSensor(sensorRegistration: SensorRegistration<Any>)
     suspend fun updateSensors(sensors: Array<Sensor<Any>>)
+
+    suspend fun getDimTimeOut(): String?
+    suspend fun setDimTimeOut(time: String?)
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCase.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCase.kt
@@ -41,4 +41,7 @@ interface IntegrationUseCase {
 
     suspend fun registerSensor(sensorRegistration: SensorRegistration<Any>)
     suspend fun updateSensors(sensors: Array<Sensor<Any>>)
+
+    suspend fun getDimTimeOut(): String?
+    suspend fun setDimTimeOut(time: String?)
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
@@ -95,4 +95,13 @@ class IntegrationUseCaseImpl @Inject constructor(
     override suspend fun updateSensors(sensors: Array<Sensor<Any>>) {
         return integrationRepository.updateSensors(sensors)
     }
+
+    override suspend fun getDimTimeOut(): String?{
+        return integrationRepository.getDimTimeOut()
+    }
+
+    override suspend fun setDimTimeOut(time: String?) {
+        return integrationRepository.setDimTimeOut(time)
+    }
+
 }

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/integration/IntegrationUseCaseImpl.kt
@@ -96,12 +96,11 @@ class IntegrationUseCaseImpl @Inject constructor(
         return integrationRepository.updateSensors(sensors)
     }
 
-    override suspend fun getDimTimeOut(): String?{
+    override suspend fun getDimTimeOut(): String? {
         return integrationRepository.getDimTimeOut()
     }
 
     override suspend fun setDimTimeOut(time: String?) {
         return integrationRepository.setDimTimeOut(time)
     }
-
 }


### PR DESCRIPTION
Add Keep Screen On in webview property 
Add setting to set timeout for dim screen : 
    -> If set to 0 or empty : no timeout, screen keep on
    -> If set above 0 : screen dim after timeout & webview paused (which allows the device to go to sleep even if there is a video stream (camera in picture entity or picture glance for example))

Resolves the following issues : [#61](https://github.com/home-assistant/home-assistant-android/issues/61), [#325](https://github.com/home-assistant/home-assistant-android/issues/325) & [#329](https://github.com/home-assistant/home-assistant-android/issues/329)

![Screenshot_20200213-173101_Home Assistant](https://user-images.githubusercontent.com/45233613/74456850-ba37ec00-4e87-11ea-8c85-9fb7bebe4941.jpg)
