### PR TITLE
Request a screenshot in the issue template and ask not to delete the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,6 +7,7 @@ about: Create a report to help us improve
 - Make sure you run the latest version of the Android app
 - Make sure you run the latest version of Home Assistant
 - Make sure to check the Companion docs for troubleshooting and configuration: https://companion.home-assistant.io/
+  DO NOT DELETE ANY TEXT from this template! All requested information is important.
 -->
 
 **Home Assistant Android version:**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -27,4 +27,6 @@ about: Create a report to help us improve
 
 ```
 
+**Screenshot of problem:**
+
 **Additional information:**


### PR DESCRIPTION
Lets start to request a screenshot of the issue so we can quickly determine what's going on.  I think this should be helpful in troubleshooting issues. 

We should also ask users not to delete the template.