### PR TITLE
Added ability for widget service calls to contain lists

### DIFF
--- a/app/src/main/res/layout/widget_button_configure_dynamic_field.xml
+++ b/app/src/main/res/layout/widget_button_configure_dynamic_field.xml
@@ -14,7 +14,7 @@
         android:padding="5dp"
         android:text="@string/label_dynamic_data" />
 
-    <AutoCompleteTextView
+    <MultiAutoCompleteTextView
         android:id="@+id/dynamic_autocomplete_textview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
I have implemented the ability for widget service data to contain lists.  Lists are indicated by comma separations, and they ignore whitespace.

Additionally, the service data will parse into proper numbers, strings, and boolean values.  Any valid YAML boolean string is accepted, including on/off and yes/no.

Partial fix for #427.  It allows lists, but not full JSON objects.  I don't know if you want to allow a raw YAML editor mode or not.