### PR TITLE
Changed permissions request screen during setup to be scrollable

### DIFF
--- a/app/src/main/res/layout/fragment_mobile_app_integration.xml
+++ b/app/src/main/res/layout/fragment_mobile_app_integration.xml
@@ -68,76 +68,80 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="@dimen/activity_margin"
-        android:orientation="vertical">
-
-        <androidx.appcompat.widget.AppCompatTextView
-            style="@style/TextAppearance.HomeAssistant.Headline"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin"
-            android:text="@string/connected_to_home_assistant"
-            android:textAlignment="center" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            style="@style/TextAppearance.HomeAssistant.Title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin"
-            android:text="@string/permission_explanation" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/location_perms"
-            style="@style/Widget.HomeAssistant.Button.Colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/grant_permission" />
-
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/location_zone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin"
-            android:text="@string/pref_location_zone_title" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/location_zone_summary"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="50dp"
-            android:text="@string/pref_location_zone_summary" />
-
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/location_background"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/activity_margin"
-            android:text="@string/pref_location_background_title" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/location_background_summary"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="50dp"
-            android:text="@string/pref_location_background_summary" />
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:gravity="end|bottom">
+            android:layout_height="wrap_content"
+            android:padding="@dimen/activity_margin"
+            android:orientation="vertical">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                style="@style/TextAppearance.HomeAssistant.Headline"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/activity_margin"
+                android:text="@string/connected_to_home_assistant"
+                android:textAlignment="center" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                style="@style/TextAppearance.HomeAssistant.Title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/activity_margin"
+                android:text="@string/permission_explanation" />
 
             <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/finish"
-                style="@style/Widget.HomeAssistant.Button.Outlined"
+                android:id="@+id/location_perms"
+                style="@style/Widget.HomeAssistant.Button.Colored"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/finish" />
-        </LinearLayout>
-    </LinearLayout>
+                android:layout_gravity="end"
+                android:text="@string/grant_permission" />
 
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/location_zone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/activity_margin"
+                android:text="@string/pref_location_zone_title" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/location_zone_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="50dp"
+                android:text="@string/pref_location_zone_summary" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/location_background"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/activity_margin"
+                android:text="@string/pref_location_background_title" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/location_background_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="50dp"
+                android:text="@string/pref_location_background_summary" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:gravity="end|bottom">
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/finish"
+                    style="@style/Widget.HomeAssistant.Button.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/finish" />
+            </LinearLayout>
+        </LinearLayout>
+    </ScrollView>
 </ViewFlipper>


### PR DESCRIPTION
A bug was mentioned in the `android` channel on the discord by user filmgarage. If the text size set on the phone is too large, it will push the `FINISH` button offscreen when asking for permissions during the initial registration/integration setup.

I have been able to recreate the issue and this PR should fix the issue by making that one section of the integration setup to be scrollable.

Apologies for the commit - it looks like a mess but it's really only changing indentation on the lines, since they're nested now.  Split view shows the changes much sensibly than unified.  I've added a ScrollView wrapping the LinearLayout and changed the LinearLayout's margins to padding.

Bug (this screen is not scrollable):
![Screenshot_20200305-103013_Home Assistant](https://user-images.githubusercontent.com/8548596/75997132-e665ec00-5ecc-11ea-818e-15e53ac5e8ab.jpg)

Fix (this screen is scrollable):
![Screenshot_20200305-102333_Home Assistant](https://user-images.githubusercontent.com/8548596/75997082-d3ebb280-5ecc-11ea-87a5-294f5c9db74e.jpg)
