### PR TITLE
Add additional input triggers for adding ssids

### DIFF
--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,8 @@
+<!-- drawable/plus.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+</vector>

--- a/app/src/main/res/layout/dialog_ssid.xml
+++ b/app/src/main/res/layout/dialog_ssid.xml
@@ -7,24 +7,42 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/inputContainer"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/manage_ssids_input"
-        app:boxBackgroundColor="@android:color/transparent">
+        android:orientation="horizontal">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/inputSsid"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:maxLines="1"
-            android:inputType="textNoSuggestions"
-            android:imeOptions="actionDone">
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/inputContainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/manage_ssids_input"
+            app:boxBackgroundColor="@android:color/transparent">
 
-        </com.google.android.material.textfield.TextInputEditText>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inputSsid"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:imeOptions="actionDone"
+                android:inputType="textNoSuggestions"
+                android:maxLines="1">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            </com.google.android.material.textfield.TextInputEditText>
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <ImageButton
+            android:id="@+id/actionAdd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:contentDescription="@null"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_plus"
+            android:tint="@android:color/white"/>
+
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvSsids"


### PR DESCRIPTION
Fixes: #498 

Should have thought about this myself mb.

Extra options have been added to add a ssid to the list. a button that will add the ssid, but also as soon as the user clicks on save, the value that has been entered (but is not empty) will be added to the list.

Will now look like this:
![Screenshot_20200306-003038](https://user-images.githubusercontent.com/60823285/76036248-db9a6e00-5f43-11ea-8d9b-093c6c968bf2.jpg)
