### PR TITLE
Add a seperate battery_state sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -45,8 +45,20 @@ class BatterySensorManager : SensorManager {
         return retVal
     }
 
-    private fun getBatteryIcon(batteryStep: Int): String {
+    private fun getBatteryIcon(batteryStep: Int, isCharging: Boolean = false, chargerType: String? = null, chargingStatus: String? = null): String {
         var batteryIcon = "mdi:battery"
+
+        if (chargingStatus == "unknown") {
+            batteryIcon += "-unknown"
+
+            return batteryIcon
+        }
+
+        if (isCharging)
+            batteryIcon += "-charging"
+
+        if (chargerType == "wireless")
+            batteryIcon += "-wireless"
 
         batteryIcon += when (batteryStep) {
             0 -> "-outline"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -45,6 +45,18 @@ class BatterySensorManager : SensorManager {
         return retVal
     }
 
+    private fun getBatteryIcon(batteryStep: Int): String {
+        var batteryIcon = "mdi:battery"
+
+        batteryIcon += when (batteryStep) {
+            0 -> "-outline"
+            10 -> ""
+            else -> "-${batteryStep}0"
+        }
+
+        return batteryIcon
+    }
+
     private fun getBatteryLevelSensor(intent: Intent): Sensor<Any>? {
         val level: Int = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
         val scale: Int = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
@@ -54,21 +66,14 @@ class BatterySensorManager : SensorManager {
             return null
         }
 
-        val percent = (level.toFloat() / scale.toFloat() * 100.0f).toInt()
-        val batteryStep = percent / 10
-
-        var batteryIcon = "mdi:battery"
-        batteryIcon += when (batteryStep) {
-            0 -> "-outline"
-            10 -> ""
-            else -> "-${batteryStep}0"
-        }
+        val percentage: Int = (level.toFloat() / scale.toFloat() * 100.0f).toInt()
+        val batteryStep: Int = percentage / 10
 
         return Sensor(
             "battery_level",
-            percent,
+            percentage,
             "sensor",
-            batteryIcon,
+            getBatteryIcon(batteryStep),
             mapOf()
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -17,6 +17,7 @@ class BatterySensorManager : SensorManager {
     override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
         return context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))?.let {
             val retVal = ArrayList<SensorRegistration<Any>>()
+
             getBatteryLevelSensor(it)?.let { sensor ->
                 retVal.add(
                     SensorRegistration(
@@ -34,6 +35,7 @@ class BatterySensorManager : SensorManager {
 
     override fun getSensors(context: Context): List<Sensor<Any>> {
         val retVal = ArrayList<Sensor<Any>>()
+
         context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))?.let {
             getBatteryLevelSensor(it)?.let { sensor ->
                 retVal.add(sensor)
@@ -44,33 +46,18 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun getBatteryLevelSensor(intent: Intent): Sensor<Any>? {
-        val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
-        val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
-        val status: Int = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+        val level: Int = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale: Int = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
 
         if (level == -1 || scale == -1) {
             Log.e(TAG, "Issue getting battery level!")
             return null
         }
 
-        val isCharging: Boolean = status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                status == BatteryManager.BATTERY_STATUS_FULL
-
-        val chargerType = when (intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)) {
-            BatteryManager.BATTERY_PLUGGED_AC -> "AC"
-            BatteryManager.BATTERY_PLUGGED_USB -> "USB"
-            BatteryManager.BATTERY_PLUGGED_WIRELESS -> "Wireless"
-            else -> "N/A"
-        }
-
         val percent = (level.toFloat() / scale.toFloat() * 100.0f).toInt()
-        var batteryIcon = "mdi:battery"
-        if (isCharging)
-            batteryIcon += "-charging"
-        if (chargerType == "Wireless")
-            batteryIcon += "-wireless"
-
         val batteryStep = percent / 10
+
+        var batteryIcon = "mdi:battery"
         batteryIcon += when (batteryStep) {
             0 -> "-outline"
             10 -> ""
@@ -82,10 +69,7 @@ class BatterySensorManager : SensorManager {
             percent,
             "sensor",
             batteryIcon,
-            mapOf(
-                "is_charging" to isCharging,
-                "charger_type" to chargerType
-            )
+            mapOf()
         )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -59,7 +59,11 @@ class BatterySensorManager : SensorManager {
         return retVal
     }
 
-    private fun getBatteryIcon(batteryStep: Int, isCharging: Boolean = false, chargerType: String? = null, chargingStatus: String? = null): String {
+    private fun getBatteryPercentage(level: Int, scale: Int): Int {
+        return (level.toFloat() / scale.toFloat() * 100.0f).toInt()
+    }
+
+    private fun getBatteryIcon(percentage: Int, isCharging: Boolean = false, chargerType: String? = null, chargingStatus: String? = null): String {
         var batteryIcon = "mdi:battery"
 
         if (chargingStatus == "unknown") {
@@ -74,6 +78,7 @@ class BatterySensorManager : SensorManager {
         if (chargerType == "wireless")
             batteryIcon += "-wireless"
 
+        val batteryStep: Int = percentage / 10
         batteryIcon += when (batteryStep) {
             0 -> "-outline"
             10 -> ""
@@ -92,14 +97,13 @@ class BatterySensorManager : SensorManager {
             return null
         }
 
-        val percentage: Int = (level.toFloat() / scale.toFloat() * 100.0f).toInt()
-        val batteryStep: Int = percentage / 10
+        val percentage: Int = getBatteryPercentage(level, scale)
 
         return Sensor(
             "battery_level",
             percentage,
             "sensor",
-            getBatteryIcon(batteryStep),
+            getBatteryIcon(percentage),
             mapOf()
         )
     }
@@ -132,14 +136,13 @@ class BatterySensorManager : SensorManager {
             else -> "unknown"
         }
 
-        val percentage: Int = (level.toFloat() / scale.toFloat() * 100.0f).toInt()
-        val batteryStep: Int = percentage / 10
+        val percentage: Int = getBatteryPercentage(level, scale)
 
         return Sensor(
             "battery_state",
             chargingStatus,
             "sensor",
-            getBatteryIcon(batteryStep, isCharging, chargerType, chargingStatus),
+            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
             mapOf(
                 "is_charging" to isCharging,
                 "charger_type" to chargerType


### PR DESCRIPTION
As proposed in #529, this PR adds a `battery_state` sensor.

The current `BatterySensor` enables a single `battery_level` sensor which contains different battery data, example:
<img width="869" alt="Screenshot 2020-03-27 at 14 30 21" src="https://user-images.githubusercontent.com/811475/77761021-a0b5c280-7037-11ea-94bd-856c55eea830.png">

With this change, there's now two sensors, `battery_level` and `battery_state`, similar to the sensors available when using the iOS application, example:
<img width="867" alt="Screenshot 2020-03-27 at 14 32 46" src="https://user-images.githubusercontent.com/811475/77761147-db1f5f80-7037-11ea-895b-3ca6381cc686.png">
